### PR TITLE
[WFLY-16296] Build Fixes

### DIFF
--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -218,6 +218,10 @@
                     <groupId>org.infinispan</groupId>
                     <artifactId>infinispan-cli-client</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.marshalling</groupId>
+                    <artifactId>jboss-marshalling-osgi</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/testsuite/integration/elytron-oidc-client/pom.xml
+++ b/testsuite/integration/elytron-oidc-client/pom.xml
@@ -111,6 +111,13 @@
             <artifactId>wildfly-elytron-oidc-client-subsystem</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- TODO confirm if this is needed -->
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-naming-client-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/testsuite/integration/elytron/pom.xml
+++ b/testsuite/integration/elytron/pom.xml
@@ -403,6 +403,13 @@
             <artifactId>jakarta.activation-api</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- TODO confirm if this is needed -->
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-naming-client-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/testsuite/integration/iiop/pom.xml
+++ b/testsuite/integration/iiop/pom.xml
@@ -102,6 +102,13 @@
             <artifactId>xom</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- TODO confirm if this is needed -->
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-naming-client-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/testsuite/integration/legacy-ejb-client/pom.xml
+++ b/testsuite/integration/legacy-ejb-client/pom.xml
@@ -87,6 +87,13 @@
             <artifactId>arquillian-junit-container</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- TODO confirm if this is needed -->
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-naming-client-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/testsuite/integration/legacy/pom.xml
+++ b/testsuite/integration/legacy/pom.xml
@@ -52,6 +52,12 @@
             <version>4.0.13.Final</version>
             <scope>test</scope>
         </dependency>
+        <!-- TODO confirm thi is needed -->
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-naming-client</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
 

--- a/testsuite/integration/microprofile-tck/pom.xml
+++ b/testsuite/integration/microprofile-tck/pom.xml
@@ -75,6 +75,15 @@
         <version.rest-client>${version.org.eclipse.microprofile.rest.client.api}</version.rest-client>
     </properties>
 
+    <dependencies>
+        <!-- TODO confirm if this is needed -->
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-naming-client-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
     <modules>
         <module>config</module>
         <module>fault-tolerance</module>

--- a/testsuite/integration/microprofile/pom.xml
+++ b/testsuite/integration/microprofile/pom.xml
@@ -317,6 +317,13 @@
             <artifactId>xom</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- TODO confirm if this is needed -->
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-naming-client-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/testsuite/integration/multinode/pom.xml
+++ b/testsuite/integration/multinode/pom.xml
@@ -98,6 +98,13 @@
             <artifactId>xom</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- TODO confirm if this is needed -->
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-naming-client-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -441,11 +441,6 @@
 
     <dependencies>
         <!-- Dependencies specific to the integration tests. -->
-        <dependency>
-            <groupId>org.wildfly</groupId>
-            <artifactId>wildfly-naming-client-jakarta</artifactId>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.wildfly.core</groupId>

--- a/testsuite/integration/rts/pom.xml
+++ b/testsuite/integration/rts/pom.xml
@@ -127,6 +127,13 @@
             <artifactId>xom</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- TODO confirm if this is needed -->
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-naming-client-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/testsuite/integration/secman/pom.xml
+++ b/testsuite/integration/secman/pom.xml
@@ -98,6 +98,13 @@
             <artifactId>xom</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- TODO confirm if this is needed -->
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-naming-client-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/testsuite/integration/vdx/pom.xml
+++ b/testsuite/integration/vdx/pom.xml
@@ -64,6 +64,13 @@
             <artifactId>wildfly-arquillian-container-domain-managed</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- TODO confirm if this is needed -->
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-naming-client-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/testsuite/integration/web/pom.xml
+++ b/testsuite/integration/web/pom.xml
@@ -166,6 +166,13 @@
             <artifactId>xom</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- TODO confirm if this is needed -->
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-naming-client-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/testsuite/integration/ws/pom.xml
+++ b/testsuite/integration/ws/pom.xml
@@ -365,6 +365,13 @@
             <artifactId>xom</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- TODO confirm if this is needed -->
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-naming-client-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/testsuite/integration/xts/pom.xml
+++ b/testsuite/integration/xts/pom.xml
@@ -216,6 +216,13 @@
             <artifactId>xom</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- TODO confirm if this is needed -->
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-naming-client-jakarta</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>


### PR DESCRIPTION
Work around the org.wildfly:wildfly-naming-client-jakarta dependency issue.

Exclude a transitive JBoss Marshalling artifact that's the wrong version and breaks a test.